### PR TITLE
Remove Jekyll website generator from repo

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,1 +1,0 @@
-theme: jekyll-theme-midnight


### PR DESCRIPTION
Any websites related to ion, ionomy etc. should have their own repos otherwise things get too messy and hard to keep track of.